### PR TITLE
Correzione su documentazione del main di Array/Puntatori/Funzioni/array/es_6.c

### DIFF
--- a/Array-Puntatori-Funzioni/array/es_6/es_6.c
+++ b/Array-Puntatori-Funzioni/array/es_6/es_6.c
@@ -6,7 +6,7 @@
  * denominata palindroma che prenda in input una stringa e restituisca
  * 1 se la stringa é palindroma altrimenti -1
  *  
- * @param char parola[] stringa di caratteri
+ * @param parola stringa di caratteri che passiamo alla funzione
  * 
  * @return La funzione restituisce 1 se la stringa è palindroma
  * @return La funzione restituisce -1 se la stringa non è palindroma
@@ -37,7 +37,7 @@ int palindroma(char parola[])
  * $ ./a.out ciao
  * $ ciao non è una stringa palindroma
  *
- * @param argv Vettore di stringhe (vettori di caratteri) contenente gli argomenti da riga di comando
+ * @param argv array di stringhe contenente gli argomenti da riga di comando
  * @param argc Numero di argomenti da riga di comando
  *
  * @return La funzione restituisce sempre 0.


### PR DESCRIPTION
Nel main era stata usata la parola vettore :(.